### PR TITLE
UIをパステル調のかわいいデザインにリデザイン

### DIFF
--- a/assets/highlight.css
+++ b/assets/highlight.css
@@ -1,72 +1,72 @@
-/* Background */ .bg { background-color: #f7f7f7; }
-/* PreWrapper */ .chroma { background-color: #f7f7f7; -webkit-text-size-adjust: none; }
-/* Error */ .chroma .err { color: #f6f8fa; background-color: #82071e }
+/* Background */ .bg { background-color: #fdedf4; }
+/* PreWrapper */ .chroma { background-color: #fdedf4; -webkit-text-size-adjust: none; }
+/* Error */ .chroma .err { color: #fff5f8; background-color: #c2547e }
 /* LineLink */ .chroma .lnlinks { outline: none; text-decoration: none; color: inherit }
 /* LineTableTD */ .chroma .lntd { vertical-align: top; padding: 0; margin: 0; border: 0; }
 /* LineTable */ .chroma .lntable { border-spacing: 0; padding: 0; margin: 0; border: 0; }
-/* LineHighlight */ .chroma .hl { background-color: #dedede }
-/* LineNumbersTable */ .chroma .lnt { white-space: pre; -webkit-user-select: none; user-select: none; margin-right: 0.4em; padding: 0 0.4em 0 0.4em;color: #7f7f7f }
-/* LineNumbers */ .chroma .ln { white-space: pre; -webkit-user-select: none; user-select: none; margin-right: 0.4em; padding: 0 0.4em 0 0.4em;color: #7f7f7f }
+/* LineHighlight */ .chroma .hl { background-color: #f5c2dc }
+/* LineNumbersTable */ .chroma .lnt { white-space: pre; -webkit-user-select: none; user-select: none; margin-right: 0.4em; padding: 0 0.4em 0 0.4em;color: #c090b8 }
+/* LineNumbers */ .chroma .ln { white-space: pre; -webkit-user-select: none; user-select: none; margin-right: 0.4em; padding: 0 0.4em 0 0.4em;color: #c090b8 }
 /* Line */ .chroma .line { display: flex; }
-/* Keyword */ .chroma .k { color: #cf222e }
-/* KeywordConstant */ .chroma .kc { color: #cf222e }
-/* KeywordDeclaration */ .chroma .kd { color: #cf222e }
-/* KeywordNamespace */ .chroma .kn { color: #cf222e }
-/* KeywordPseudo */ .chroma .kp { color: #cf222e }
-/* KeywordReserved */ .chroma .kr { color: #cf222e }
-/* KeywordType */ .chroma .kt { color: #cf222e }
-/* NameAttribute */ .chroma .na { color: #1f2328 }
-/* NameClass */ .chroma .nc { color: #1f2328 }
-/* NameConstant */ .chroma .no { color: #0550ae }
-/* NameDecorator */ .chroma .nd { color: #0550ae }
-/* NameEntity */ .chroma .ni { color: #6639ba }
-/* NameLabel */ .chroma .nl { color: #990000; font-weight: bold }
-/* NameNamespace */ .chroma .nn { color: #24292e }
-/* NameOther */ .chroma .nx { color: #1f2328 }
-/* NameTag */ .chroma .nt { color: #0550ae }
-/* NameBuiltin */ .chroma .nb { color: #6639ba }
-/* NameBuiltinPseudo */ .chroma .bp { color: #6a737d }
-/* NameVariable */ .chroma .nv { color: #953800 }
-/* NameVariableClass */ .chroma .vc { color: #953800 }
-/* NameVariableGlobal */ .chroma .vg { color: #953800 }
-/* NameVariableInstance */ .chroma .vi { color: #953800 }
-/* NameVariableMagic */ .chroma .vm { color: #953800 }
-/* NameFunction */ .chroma .nf { color: #6639ba }
-/* NameFunctionMagic */ .chroma .fm { color: #6639ba }
-/* LiteralString */ .chroma .s { color: #0a3069 }
-/* LiteralStringAffix */ .chroma .sa { color: #0a3069 }
-/* LiteralStringBacktick */ .chroma .sb { color: #0a3069 }
-/* LiteralStringChar */ .chroma .sc { color: #0a3069 }
-/* LiteralStringDelimiter */ .chroma .dl { color: #0a3069 }
-/* LiteralStringDoc */ .chroma .sd { color: #0a3069 }
-/* LiteralStringDouble */ .chroma .s2 { color: #0a3069 }
-/* LiteralStringEscape */ .chroma .se { color: #0a3069 }
-/* LiteralStringHeredoc */ .chroma .sh { color: #0a3069 }
-/* LiteralStringInterpol */ .chroma .si { color: #0a3069 }
-/* LiteralStringOther */ .chroma .sx { color: #0a3069 }
-/* LiteralStringRegex */ .chroma .sr { color: #0a3069 }
-/* LiteralStringSingle */ .chroma .s1 { color: #0a3069 }
-/* LiteralStringSymbol */ .chroma .ss { color: #032f62 }
-/* LiteralNumber */ .chroma .m { color: #0550ae }
-/* LiteralNumberBin */ .chroma .mb { color: #0550ae }
-/* LiteralNumberFloat */ .chroma .mf { color: #0550ae }
-/* LiteralNumberHex */ .chroma .mh { color: #0550ae }
-/* LiteralNumberInteger */ .chroma .mi { color: #0550ae }
-/* LiteralNumberIntegerLong */ .chroma .il { color: #0550ae }
-/* LiteralNumberOct */ .chroma .mo { color: #0550ae }
-/* Operator */ .chroma .o { color: #0550ae }
-/* OperatorWord */ .chroma .ow { color: #0550ae }
-/* Punctuation */ .chroma .p { color: #1f2328 }
-/* Comment */ .chroma .c { color: #57606a }
-/* CommentHashbang */ .chroma .ch { color: #57606a }
-/* CommentMultiline */ .chroma .cm { color: #57606a }
-/* CommentSingle */ .chroma .c1 { color: #57606a }
-/* CommentSpecial */ .chroma .cs { color: #57606a }
-/* CommentPreproc */ .chroma .cp { color: #57606a }
-/* CommentPreprocFile */ .chroma .cpf { color: #57606a }
-/* GenericDeleted */ .chroma .gd { color: #82071e; background-color: #ffebe9 }
-/* GenericEmph */ .chroma .ge { color: #1f2328 }
-/* GenericInserted */ .chroma .gi { color: #116329; background-color: #dafbe1 }
-/* GenericOutput */ .chroma .go { color: #1f2328 }
+/* Keyword */ .chroma .k { color: #c2547e }
+/* KeywordConstant */ .chroma .kc { color: #c2547e }
+/* KeywordDeclaration */ .chroma .kd { color: #c2547e }
+/* KeywordNamespace */ .chroma .kn { color: #c2547e }
+/* KeywordPseudo */ .chroma .kp { color: #c2547e }
+/* KeywordReserved */ .chroma .kr { color: #c2547e }
+/* KeywordType */ .chroma .kt { color: #c2547e }
+/* NameAttribute */ .chroma .na { color: #4a3261 }
+/* NameClass */ .chroma .nc { color: #8b5cba }
+/* NameConstant */ .chroma .no { color: #5b8fa8 }
+/* NameDecorator */ .chroma .nd { color: #8b5cba }
+/* NameEntity */ .chroma .ni { color: #8b5cba }
+/* NameLabel */ .chroma .nl { color: #c2547e; font-weight: bold }
+/* NameNamespace */ .chroma .nn { color: #4a3261 }
+/* NameOther */ .chroma .nx { color: #4a3261 }
+/* NameTag */ .chroma .nt { color: #5b8fa8 }
+/* NameBuiltin */ .chroma .nb { color: #8b5cba }
+/* NameBuiltinPseudo */ .chroma .bp { color: #9e86b5 }
+/* NameVariable */ .chroma .nv { color: #c07850 }
+/* NameVariableClass */ .chroma .vc { color: #c07850 }
+/* NameVariableGlobal */ .chroma .vg { color: #c07850 }
+/* NameVariableInstance */ .chroma .vi { color: #c07850 }
+/* NameVariableMagic */ .chroma .vm { color: #c07850 }
+/* NameFunction */ .chroma .nf { color: #8b5cba }
+/* NameFunctionMagic */ .chroma .fm { color: #8b5cba }
+/* LiteralString */ .chroma .s { color: #6a5acd }
+/* LiteralStringAffix */ .chroma .sa { color: #6a5acd }
+/* LiteralStringBacktick */ .chroma .sb { color: #6a5acd }
+/* LiteralStringChar */ .chroma .sc { color: #6a5acd }
+/* LiteralStringDelimiter */ .chroma .dl { color: #6a5acd }
+/* LiteralStringDoc */ .chroma .sd { color: #6a5acd }
+/* LiteralStringDouble */ .chroma .s2 { color: #6a5acd }
+/* LiteralStringEscape */ .chroma .se { color: #8b5cba }
+/* LiteralStringHeredoc */ .chroma .sh { color: #6a5acd }
+/* LiteralStringInterpol */ .chroma .si { color: #6a5acd }
+/* LiteralStringOther */ .chroma .sx { color: #6a5acd }
+/* LiteralStringRegex */ .chroma .sr { color: #6a5acd }
+/* LiteralStringSingle */ .chroma .s1 { color: #6a5acd }
+/* LiteralStringSymbol */ .chroma .ss { color: #6a5acd }
+/* LiteralNumber */ .chroma .m { color: #5b8fa8 }
+/* LiteralNumberBin */ .chroma .mb { color: #5b8fa8 }
+/* LiteralNumberFloat */ .chroma .mf { color: #5b8fa8 }
+/* LiteralNumberHex */ .chroma .mh { color: #5b8fa8 }
+/* LiteralNumberInteger */ .chroma .mi { color: #5b8fa8 }
+/* LiteralNumberIntegerLong */ .chroma .il { color: #5b8fa8 }
+/* LiteralNumberOct */ .chroma .mo { color: #5b8fa8 }
+/* Operator */ .chroma .o { color: #c2547e }
+/* OperatorWord */ .chroma .ow { color: #c2547e }
+/* Punctuation */ .chroma .p { color: #4a3261 }
+/* Comment */ .chroma .c { color: #9e86b5 }
+/* CommentHashbang */ .chroma .ch { color: #9e86b5 }
+/* CommentMultiline */ .chroma .cm { color: #9e86b5 }
+/* CommentSingle */ .chroma .c1 { color: #9e86b5 }
+/* CommentSpecial */ .chroma .cs { color: #9e86b5 }
+/* CommentPreproc */ .chroma .cp { color: #9e86b5 }
+/* CommentPreprocFile */ .chroma .cpf { color: #9e86b5 }
+/* GenericDeleted */ .chroma .gd { color: #c2547e; background-color: #fde8f3 }
+/* GenericEmph */ .chroma .ge { color: #4a3261; font-style: italic }
+/* GenericInserted */ .chroma .gi { color: #8b5cba; background-color: #f5eeff }
+/* GenericOutput */ .chroma .go { color: #9e86b5 }
 /* GenericUnderline */ .chroma .gl { text-decoration: underline }
-/* TextWhitespace */ .chroma .w { color: #ffffff }
+/* TextWhitespace */ .chroma .w { color: #fff5f8 }

--- a/assets/kawaii.css
+++ b/assets/kawaii.css
@@ -1,0 +1,282 @@
+/* kawaii.css - パステル調UIスタイル (Zen Maru Gothic + ピンク&ラベンダーパレット) */
+
+/* Google Fonts は page.html / dirlist.html の <link> で読み込む */
+
+/* ===== ボディ & 全体設定 ===== */
+body {
+  background-color: #fff5f8;
+  font-family: 'Zen Maru Gothic', 'Hiragino Maru Gothic ProN', 'BIZ UDPGothic', sans-serif;
+  color: #4a3261;
+}
+
+/* ===== markdown-body CSS変数オーバーライド (ライトモード) ===== */
+.markdown-body {
+  --color-canvas-default: #fff5f8;
+  --color-canvas-subtle: #fdedf4;
+  --color-border-default: #f0c2d8;
+  --color-border-muted: #f5c2dc;
+  --color-neutral-muted: rgba(220, 160, 195, 0.15);
+  --color-accent-fg: #c2547e;
+  --color-accent-emphasis: #c2547e;
+  --color-fg-default: #4a3261;
+  --color-fg-muted: #9e86b5;
+  --color-fg-subtle: #9e86b5;
+  --color-prettylights-syntax-comment: #9e86b5;
+  --color-prettylights-syntax-constant: #5b8fa8;
+  --color-prettylights-syntax-entity: #8b5cba;
+  --color-prettylights-syntax-storage-modifier-import: #4a3261;
+  --color-prettylights-syntax-entity-tag: #5b8fa8;
+  --color-prettylights-syntax-keyword: #c2547e;
+  --color-prettylights-syntax-string: #6a5acd;
+  --color-prettylights-syntax-variable: #c07850;
+  --color-prettylights-syntax-brackethighlighter-unmatched: #c2547e;
+  --color-prettylights-syntax-invalid-illegal-text: #fff5f8;
+  --color-prettylights-syntax-invalid-illegal-bg: #c2547e;
+  --color-prettylights-syntax-carriage-return-text: #fff5f8;
+  --color-prettylights-syntax-carriage-return-bg: #c2547e;
+  --color-prettylights-syntax-string-regexp: #6a5acd;
+  --color-prettylights-syntax-markup-list: #c07850;
+  --color-prettylights-syntax-markup-heading: #4a3261;
+  --color-prettylights-syntax-markup-italic: #4a3261;
+  --color-prettylights-syntax-markup-bold: #4a3261;
+  --color-prettylights-syntax-markup-deleted-text: #c2547e;
+  --color-prettylights-syntax-markup-deleted-bg: #fdedf4;
+  --color-prettylights-syntax-markup-inserted-text: #8b5cba;
+  --color-prettylights-syntax-markup-inserted-bg: #f5eeff;
+  --color-prettylights-syntax-markup-changed-text: #c07850;
+  --color-prettylights-syntax-markup-changed-bg: #fff3e8;
+  --color-prettylights-syntax-markup-ignored-text: #9e86b5;
+  --color-prettylights-syntax-markup-ignored-bg: #fdedf4;
+  --color-prettylights-syntax-meta-diff-range: #8b5cba;
+  --color-prettylights-syntax-brackethighlighter-angle: #9e86b5;
+  --color-prettylights-syntax-sublimelinter-gutter-mark: #f0c2d8;
+  --color-prettylights-syntax-constant-other-reference-link: #6a5acd;
+}
+
+/* ===== markdown-body 追加スタイル ===== */
+.markdown-body {
+  background-color: transparent;
+  color: #4a3261;
+  font-family: 'Zen Maru Gothic', 'Hiragino Maru Gothic ProN', 'BIZ UDPGothic', sans-serif;
+}
+
+.markdown-body a {
+  color: #c2547e;
+}
+
+.markdown-body a:hover {
+  color: #a03060;
+}
+
+.markdown-body h1,
+.markdown-body h2 {
+  border-bottom-color: #f5c2dc;
+}
+
+.markdown-body blockquote {
+  border-left-color: #f0a0c8;
+  color: #9e86b5;
+}
+
+.markdown-body hr {
+  background-color: #f0c2d8;
+}
+
+.markdown-body table tr {
+  background-color: #fff5f8;
+  border-top-color: #f0c2d8;
+}
+
+.markdown-body table tr:nth-child(2n) {
+  background-color: #fdedf4;
+}
+
+.markdown-body table th,
+.markdown-body table td {
+  border-color: #f0c2d8;
+}
+
+.markdown-body table th {
+  background-color: #fde8f3;
+}
+
+.markdown-body code,
+.markdown-body tt {
+  background-color: rgba(220, 160, 195, 0.15);
+  color: #8b5cba;
+}
+
+.markdown-body pre {
+  background-color: #fdedf4;
+  border: 1px solid #f0c2d8;
+}
+
+.markdown-body pre code {
+  background-color: transparent;
+}
+
+/* ===== パンくずナビ ===== */
+nav.breadcrumb {
+  margin-bottom: 1em;
+  font-size: 0.9em;
+  color: #9e86b5;
+  font-family: 'Zen Maru Gothic', 'Hiragino Maru Gothic ProN', 'BIZ UDPGothic', sans-serif;
+}
+
+nav.breadcrumb a {
+  color: #c2547e;
+  text-decoration: none;
+}
+
+nav.breadcrumb a:hover {
+  color: #a03060;
+  text-decoration: underline;
+}
+
+/* ===== ディレクトリ一覧 ===== */
+.dir-list-link {
+  margin-bottom: 0.8em;
+  font-size: 0.9em;
+}
+
+.dir-list-link a {
+  color: #c2547e;
+  text-decoration: none;
+  padding: 0.2em 0.6em;
+  border: 1px solid #f0c2d8;
+  border-radius: 1em;
+  background-color: #fdedf4;
+  transition: background-color 0.2s ease, border-color 0.2s ease;
+}
+
+.dir-list-link a:hover {
+  background-color: #f5c2dc;
+  border-color: #e090b8;
+  color: #a03060;
+}
+
+/* ディレクトリリスト内の [dir] プレフィックス */
+.markdown-body li a {
+  color: #c2547e;
+}
+
+.markdown-body li a:hover {
+  color: #a03060;
+}
+
+/* [dir] テキストのスタイル */
+.markdown-body li a:has(> *:first-child) {
+  /* ディレクトリエントリのかわいいスタイル */
+}
+
+/* ===== ダークモード ===== */
+@media (prefers-color-scheme: dark) {
+  body {
+    background-color: #1a1025;
+    color: #d4c0e8;
+  }
+
+  .markdown-body {
+    --color-canvas-default: #1a1025;
+    --color-canvas-subtle: #251535;
+    --color-border-default: #4a2860;
+    --color-border-muted: #3d2255;
+    --color-neutral-muted: rgba(160, 100, 180, 0.15);
+    --color-accent-fg: #e896b8;
+    --color-accent-emphasis: #e896b8;
+    --color-fg-default: #d4c0e8;
+    --color-fg-muted: #9e86b5;
+    --color-fg-subtle: #7a6090;
+    --color-prettylights-syntax-comment: #9e86b5;
+    --color-prettylights-syntax-constant: #82c0d8;
+    --color-prettylights-syntax-entity: #c090e8;
+    --color-prettylights-syntax-storage-modifier-import: #d4c0e8;
+    --color-prettylights-syntax-entity-tag: #82c0d8;
+    --color-prettylights-syntax-keyword: #e896b8;
+    --color-prettylights-syntax-string: #a090e0;
+    --color-prettylights-syntax-variable: #e0a870;
+    --color-prettylights-syntax-string-regexp: #a090e0;
+    --color-prettylights-syntax-markup-list: #e0a870;
+    --color-prettylights-syntax-markup-heading: #d4c0e8;
+  }
+
+  .markdown-body {
+    background-color: transparent;
+    color: #d4c0e8;
+  }
+
+  .markdown-body a {
+    color: #e896b8;
+  }
+
+  .markdown-body a:hover {
+    color: #f0b0cc;
+  }
+
+  .markdown-body h1,
+  .markdown-body h2 {
+    border-bottom-color: #4a2860;
+  }
+
+  .markdown-body blockquote {
+    border-left-color: #6a3880;
+    color: #9e86b5;
+  }
+
+  .markdown-body hr {
+    background-color: #4a2860;
+  }
+
+  .markdown-body table tr {
+    background-color: #1a1025;
+    border-top-color: #4a2860;
+  }
+
+  .markdown-body table tr:nth-child(2n) {
+    background-color: #251535;
+  }
+
+  .markdown-body table th,
+  .markdown-body table td {
+    border-color: #4a2860;
+  }
+
+  .markdown-body table th {
+    background-color: #2d1845;
+  }
+
+  .markdown-body code,
+  .markdown-body tt {
+    background-color: rgba(160, 100, 180, 0.2);
+    color: #c090e8;
+  }
+
+  .markdown-body pre {
+    background-color: #251535;
+    border: 1px solid #4a2860;
+  }
+
+  nav.breadcrumb {
+    color: #9e86b5;
+  }
+
+  nav.breadcrumb a {
+    color: #e896b8;
+  }
+
+  nav.breadcrumb a:hover {
+    color: #f0b0cc;
+  }
+
+  .dir-list-link a {
+    color: #e896b8;
+    border-color: #4a2860;
+    background-color: #251535;
+  }
+
+  .dir-list-link a:hover {
+    background-color: #3d2255;
+    border-color: #6a3880;
+    color: #f0b0cc;
+  }
+}

--- a/internal/tmpl/templates/dirlist.html
+++ b/internal/tmpl/templates/dirlist.html
@@ -4,12 +4,13 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>{{.Title}}</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Zen+Maru+Gothic:wght@400;700&display=swap" rel="stylesheet">
 <link rel="stylesheet" href="/assets/github-markdown.css">
+<link rel="stylesheet" href="/assets/kawaii.css">
 <style>
 body { box-sizing: border-box; min-width: 200px; max-width: 980px; margin: 0 auto; padding: 45px; }
-nav.breadcrumb { margin-bottom: 1em; font-size: 0.9em; color: #586069; }
-nav.breadcrumb a { color: #0366d6; text-decoration: none; }
-nav.breadcrumb a:hover { text-decoration: underline; }
 </style>
 </head>
 <body>

--- a/internal/tmpl/templates/page.html
+++ b/internal/tmpl/templates/page.html
@@ -4,13 +4,14 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>{{.Title}}</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Zen+Maru+Gothic:wght@400;700&display=swap" rel="stylesheet">
 <link rel="stylesheet" href="/assets/github-markdown.css">
 <link rel="stylesheet" href="/assets/highlight.css">
+<link rel="stylesheet" href="/assets/kawaii.css">
 <style>
 body { box-sizing: border-box; min-width: 200px; max-width: 980px; margin: 0 auto; padding: 45px; }
-nav.breadcrumb { margin-bottom: 1em; font-size: 0.9em; color: #586069; }
-nav.breadcrumb a { color: #0366d6; text-decoration: none; }
-nav.breadcrumb a:hover { text-decoration: underline; }
 </style>
 </head>
 <body>


### PR DESCRIPTION
## 概要

UIをパステル調のかわいい（kawaii）デザインにリデザインしました。

Closes #2

## 変更内容

- `assets/kawaii.css` を新規追加: パステルカラーベースのかわいいデザインCSS
- `assets/highlight.css` を更新: シンタックスハイライトのスタイルをリデザインに合わせて調整
- `internal/tmpl/templates/dirlist.html` を更新: kawaii.cssを適用
- `internal/tmpl/templates/page.html` を更新: kawaii.cssを適用

## テスト計画

- [ ] ディレクトリ一覧ページの表示確認
- [ ] Markdownページの表示確認
- [ ] シンタックスハイライトの表示確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)